### PR TITLE
Grey team onboarding document

### DIFF
--- a/docs/team/grey.md
+++ b/docs/team/grey.md
@@ -1,0 +1,11 @@
+# Grey
+
+## Role
+- DevOps / QA
+
+## Availability
+- Monday–Friday: 6:00 PM – 9:00 PM (Central)
+
+## Engineering principle
+- All changes go through small pull requests with review
+- Why: This keeps the codebase stable and helps catch issues early while sharing context with the team.


### PR DESCRIPTION
Adds Grey’s onboarding information under docs/team for the Week 2 assignment.