### PR TITLE
Add Risks and Trade-Offs Architecture Artifact

### DIFF
--- a/docs/team/risks-tradeoffs.md
+++ b/docs/team/risks-tradeoffs.md
@@ -1,16 +1,25 @@
 # Risks and Trade-Offs (Team)
 
 ## Trade-Offs
-- **Rules-based logic vs ML personalization:** explainable and implementable now, but less adaptive long-term.
-- **Local prototype vs scalable deployment:** minimal infrastructure now; scaling needs DB + hosting changes.
-- **Transparency vs sophistication:** decisions are understandable, but may not optimize learning outcomes as well as ML.
+- **Rules-based logic vs ML personalization:** Explainable and implementable now, but less adaptive in the long term.
+- **Local prototype vs scalable deployment:** Minimal infrastructure initially; scaling requires database and hosting changes.
+- **Transparency vs sophistication:** Decisions are understandable but may not optimize learning outcomes as well as ML approaches.
 
 ## Key Risks and Mitigations
-- **Risk: Rule thresholds produce weak recommendations**
-  - Mitigation: calibrate using sample student profiles; allow teacher override; log decision rationale.
-- **Risk: Data quality issues (missing assessments, inconsistent scoring)**
-  - Mitigation: input validation; default handling; clear error feedback.
-- **Risk: Privacy and student data exposure**
-  - Mitigation: minimize stored PII; role-based access; local-only storage for prototype.
-- **Risk: SQLite / local DB limits**
-  - Mitigation: document migration plan to hosted DB; isolate persistence behind interfaces.
+- **Risk: Rule thresholds produce weak recommendations**  
+  Calibrate rules using sample student profiles; allow teacher override; log decision rationale.
+
+- **Risk: Data quality issues (missing assessments, inconsistent scoring)**  
+  Input validation, default handling, and clear error feedback.
+
+- **Risk: Privacy and student data exposure**  
+  Minimize stored PII, enforce role-based access control, and use local-only storage for the prototype.
+
+- **Risk: Role-based access control bugs expose teacher or administrator views to students**  
+  Enforce server-side role checks in addition to UI controls and add tests for role-gated routes.
+
+- **Risk: SQLite / local database limits**  
+  Document a migration plan to a hosted database and isolate persistence behind well-defined interfaces.
+
+- **Risk: Poor content tagging or mapping reduces recommendation effectiveness**  
+  Require explicit grade, topic, and skill tags for all content and allow teacher feedback or overrides.


### PR DESCRIPTION
Adds the required Risks and Trade-Offs (Team) document per architecture rubric.