### PR TITLE
Add Week 9 beta sprint documentation

### DIFF
--- a/docs/beta/bug-triage.md
+++ b/docs/beta/bug-triage.md
@@ -1,0 +1,129 @@
+# Bug Triage + Regression Protection
+
+## Issue 1
+**Title:** Invalid score error message is unclear  
+**Severity:** Major  
+
+**Repro Steps:**
+1. Start the server locally
+2. Create a student
+3. Submit an assessment with an invalid score such as `-5` or `150`
+4. Observe the API response
+
+**Expected Behavior:**  
+The API should return a clear validation message explaining that the score must be within the accepted range.
+
+**Actual Behavior:**  
+The response is too vague or not specific enough to explain the failure clearly.
+
+**Status:** Fixed  
+**Evidence:** (PROJECT LINK PENDING)
+
+---
+
+## Issue 2
+**Title:** Unknown student ID does not return a sufficiently clear error  
+**Severity:** Major  
+
+**Repro Steps:**
+1. Start the server locally
+2. Request an assessment submission or recommendation lookup using a fake student ID
+3. Observe the API response
+
+**Expected Behavior:**  
+The API should clearly state that the student was not found for the provided `studentId`.
+
+**Actual Behavior:**  
+The response does not provide enough detail to quickly diagnose the problem.
+
+**Status:** Fixed  
+**Evidence:** (PROJECT LINK PENDING)
+
+---
+
+## Issue 3
+**Title:** No request logging for health endpoint  
+**Severity:** Minor  
+
+**Repro Steps:**
+1. Start the server locally
+2. Call `GET /api/health`
+3. Check the server output
+
+**Expected Behavior:**  
+A log entry should confirm that the request was received and handled successfully.
+
+**Actual Behavior:**  
+No useful diagnostic output is produced for the request.
+
+**Status:** Fixed  
+**Evidence:** (PROJECT LINK PENDING)
+
+---
+
+## Issue 4
+**Title:** No request logging for student creation  
+**Severity:** Minor  
+
+**Repro Steps:**
+1. Start the server locally
+2. Call `POST /api/students`
+3. Check the server output
+
+**Expected Behavior:**  
+A log entry should identify the endpoint and indicate that the request completed.
+
+**Actual Behavior:**  
+No useful request log is available.
+
+**Status:** Open  
+**Evidence:** (PROJECT LINK PENDING_IF FIXED)
+
+---
+
+## Issue 5
+**Title:** Assessment submission failures are hard to trace  
+**Severity:** Critical  
+
+**Repro Steps:**
+1. Start the server locally
+2. Submit an invalid assessment request
+3. Observe the response and server output
+
+**Expected Behavior:**  
+The response and log output should make it easy to understand what failed and where it failed.
+
+**Actual Behavior:**  
+The failure is not logged with enough detail to trace the issue efficiently.
+
+**Status:** Open  
+**Evidence:** (PROJECT LINK PENDING_IF FIXED)
+
+---
+
+## Issue 6
+**Title:** Recommendation lookup failure lacks diagnostic context  
+**Severity:** Major  
+
+**Repro Steps:**
+1. Start the server locally
+2. Request the latest recommendation for an invalid or missing student record
+3. Observe the response and server output
+
+**Expected Behavior:**  
+The system should return a clear error response and log enough context to troubleshoot the issue.
+
+**Actual Behavior:**  
+The result does not provide enough diagnostic information.
+
+**Status:** Open  
+**Evidence:** (PROJECT LINK PENDING_IF FIXED)
+
+---
+
+## Regression Protection Summary
+The Week 9 fixes should include regression tests for the two most important corrected issues:
+- invalid score validation
+- invalid or unknown student ID handling
+
+These tests should run in CI so the same bugs do not silently return in later changes.

--- a/docs/beta/observability.md
+++ b/docs/beta/observability.md
@@ -1,0 +1,27 @@
+# Observability Starter + Error Handling
+
+## Where Logs Live
+Logs are currently written to the server console output while the application is running locally. Informational request logs should appear on standard output, and error logs should appear on standard error.
+
+## How to View Logs
+Run the server locally from the terminal using the project README instructions. While the server is running, make requests to the API endpoints and observe the log output in the same terminal session.
+
+## What Events Are Logged
+The application should log the following events:
+- health endpoint requests
+- student creation requests
+- assessment submission requests
+- latest recommendation requests
+- validation failures
+- student lookup failures
+
+## How to Correlate a User Action to a Log Entry
+Each log entry should include the endpoint and action context. When available, the log should also include the `studentId` so a request can be connected to a specific learner action. This makes it easier to trace a request from the API call to the resulting response or failure.
+
+## Sample Log Snippet
+```text
+[INFO] endpoint=/api/health status=200 action=health_check
+[INFO] endpoint=/api/students status=201 action=create_student studentId=student-1
+[INFO] endpoint=/api/students/{studentId}/assessments status=201 action=submit_assessment studentId=student-1
+[ERROR] endpoint=/api/students/{studentId}/assessments status=400 action=submit_assessment reason=invalid_score
+[ERROR] endpoint=/api/students/{studentId}/recommendations/latest status=404 action=get_latest_recommendation reason=student_not_found

--- a/docs/beta/week9-pr-index.md
+++ b/docs/beta/week9-pr-index.md
@@ -1,0 +1,21 @@
+# Week 9 PR Index
+
+## PR 1
+**PR Link:** (PR LINK PENDING)
+**Backlog Item:** Add request logging for key API actions  
+**Impact:** Adds basic observability for the main MVP API workflow so requests can be traced during testing and demos.
+
+## PR 2
+**PR Link:** (PR LINK PENDING)
+**Backlog Item:** Improve invalid input error messages and structured error logs  
+**Impact:** Makes common failure cases easier to understand and reduces time spent debugging invalid requests.
+
+## PR 3
+**PR Link:** (PR LINK PENDING)
+**Backlog Item:** Fix bugs and add regression tests  
+**Impact:** Prevents known failures from returning by capturing the expected behavior in automated tests.
+
+## Notes
+- Each PR should be small and focused
+- Each PR should have review approval and CI passing before merge
+- Replace each placeholder with the real GitHub PR link before submission

--- a/docs/beta/week9-sprint.md
+++ b/docs/beta/week9-sprint.md
@@ -1,0 +1,51 @@
+# Week 9 Sprint Goal + Committed Backlog
+
+## Sprint Goal
+By Friday, users can complete the MVP workflow more reliably with clearer errors, better diagnostics, and regression protection.
+
+## Committed Backlog Items
+
+### 1. Add request logging for key API actions
+**Owner:** Grey
+
+**Acceptance Criteria:**
+- Log entries are written for `GET /api/health`
+- Log entries are written for `POST /api/students`
+- Log entries are written for `POST /api/students/{studentId}/assessments`
+- Log entries are written for `GET /api/students/{studentId}/recommendations/latest`
+
+### 2. Add structured error logs for common failures
+**Owner:** Grey
+
+**Acceptance Criteria:**
+- Validation failures are logged with endpoint context
+- Student lookup failures are logged with endpoint context
+- Error logs include enough detail to understand what failed
+
+### 3. Improve invalid input error messages
+**Owner:** Grey
+
+**Acceptance Criteria:**
+- Invalid score returns a clear error message
+- Invalid or unknown student ID returns a clear error message
+- API responses explain what failed in a way that is easy to debug
+
+### 4. Add regression tests for fixed bugs
+**Owner:** Grey
+
+**Acceptance Criteria:**
+- At least 2 fixed bugs have matching automated tests
+- Tests run successfully in CI
+- The tests would fail again if the bug returned
+
+### 5. Document sprint evidence, bug triage, and observability
+**Owner:** Grey
+
+**Acceptance Criteria:**
+- `docs/beta/week9-pr-index.md` exists
+- `docs/beta/bug-triage.md` exists
+- `docs/beta/observability.md` exists
+- Evidence links are added before submission
+
+## Evidence
+Project Board Sprint View: (PROJECT LINK PENDING)


### PR DESCRIPTION
## Summary
Adds the required Week 9 beta sprint documentation.

## Changes
- Added docs/beta/week9-sprint.md
- Added docs/beta/week9-pr-index.md
- Added docs/beta/bug-triage.md
- Added docs/beta/observability.md

## Why
These documents are required for the Week 9 Beta Sprint 1 Evidence Package.

## How to test
1. Open the docs/beta folder
2. Verify all four Week 9 documents exist
3. Confirm the sprint goal, PR index, bug triage, and observability documentation are present