### PR TITLE
Week 11 Evidence Links Fix (CI + Sprint)

### DIFF
--- a/docs/beta/week11-ci.md
+++ b/docs/beta/week11-ci.md
@@ -99,7 +99,7 @@ https://github.com/Georgia-Southwestern-State-Univeristy/term-project-group-7/ac
 ## Week 11 Evidence
 
 **PR Link:**  
-(PR LINK WILL BE INSERTED ONCE CREATED)
+https://github.com/Georgia-Southwestern-State-Univeristy/term-project-group-7/pull/40
 
 **Passing CI Run:**  
-(PR LINK WILL BE INSERTED ONCE CREATED)
+https://github.com/Georgia-Southwestern-State-Univeristy/term-project-group-7/actions/runs/23611166317

--- a/docs/beta/week11-sprint.md
+++ b/docs/beta/week11-sprint.md
@@ -86,4 +86,5 @@ https://github.com/orgs/Georgia-Southwestern-State-Univeristy/projects
   `docs/beta/week10-sprint.md`
 
 **Week 11 submission PR:**  
-(PR LINK WILL BE REPLACED WHEN CREATED)
+Week 11 submission PR:
+https://github.com/Georgia-Southwestern-State-Univeristy/term-project-group-7/pull/40


### PR DESCRIPTION
## Summary
This PR adds missing evidence links required for Week 11 submission.

## Changes
- Added Week 11 PR link to sprint.md
- Added Week 11 PR + CI run links to ci.md

## Why this matters
These links provide direct traceability between:
- implementation (PR)
- verification (CI)
- documentation (Week 11 files)